### PR TITLE
Fix Scrolling Issue in EmojiSelect

### DIFF
--- a/src/Components/Inputs/EmojiSelect.js
+++ b/src/Components/Inputs/EmojiSelect.js
@@ -39,6 +39,7 @@ class EmojiSelect extends React.Component {
   constructor() {
     super();
     this.searchInputRef = React.createRef(); // <- so that the search can be auto-focused on
+    this.emojiScrollBox = React.createRef(); // so that outside scrolling can be prevented
     this.state = {
       selectSkinColorActive : false,
       hoveredEmojiId        : '',
@@ -48,7 +49,41 @@ class EmojiSelect extends React.Component {
 
   componentDidMount = () => {
     this.searchInputRef.current.focus();
+    this.emojiScrollBox.current.addEventListener('scroll',
+      this.preventOutsideScrolling,
+      false
+    );
   }
+
+  componentWillUnmount = () => {
+    this.emojiScrollBox.current.removeEventListener('scroll', 
+      this.preventOutsideScrolling, 
+      false
+    );
+  }
+
+  // Scrolling -----------------------------------------------------------------
+
+  preventOutsideScrolling = () => {
+    /**
+     * Prevents scrolling of containers outside the EmojiSelect window.
+     * Once the window is scrolled to the bottom or top set the scrollTop back
+     * to the inside of the container, preventing it ever actually reaching the
+     * top or bottom of the container.
+     */
+    let scrollTop = this.emojiScrollBox.current.scrollTop;
+    let scrollHeight = this.emojiScrollBox.current.scrollHeight;
+    let offsetHeight = this.emojiScrollBox.current.offsetHeight;
+    let contentHeight = scrollHeight - offsetHeight;
+
+    if (contentHeight <= scrollTop) {  // Box is scrolled to the bottom
+      this.emojiScrollBox.current.scrollTop = contentHeight - 1;
+    } else if (scrollTop === 0) {  // Box is scrolled to the top
+      this.emojiScrollBox.current.scrollTop = 1;
+    }
+
+  }
+
   // Input ---------------------------------------------------------------------
 
   onClick_selectSkinColor = () => {
@@ -167,7 +202,7 @@ class EmojiSelect extends React.Component {
     return (
       <div id="EmojiSelect">
         {this.renderTopBar()}
-        <div id="middle-container">
+        <div id="middle-container" ref={this.emojiScrollBox}>
           {this.renderEmojis()}
         </div>
         <div id="bottom-container">

--- a/src/Components/Inputs/EmojiSelect.js
+++ b/src/Components/Inputs/EmojiSelect.js
@@ -86,8 +86,6 @@ class EmojiSelect extends React.Component {
     let offsetHeight = this.emojiScrollBox.current.offsetHeight;
     let contentHeight = scrollHeight - offsetHeight;
 
-    console.log(scrollTop, scrollHeight, offsetHeight, contentHeight);
-
     if (contentHeight <= scrollTop) {  // Box is scrolled to the bottom
       this.emojiScrollBox.current.scrollTop = contentHeight - 1;
     } else if (scrollTop === 0) {  // Box is scrolled to the top

--- a/src/Components/Inputs/EmojiSelect.js
+++ b/src/Components/Inputs/EmojiSelect.js
@@ -49,6 +49,16 @@ class EmojiSelect extends React.Component {
 
   componentDidMount = () => {
     this.searchInputRef.current.focus();
+
+
+    /* Scrolling */
+    /**
+     * Initialize scrollTop so that when the container is first loaded it
+     * will detect a scroll event. If the scrollTop was set to 0 and the
+     * container was scolled up, it would not detect a scroll event but still
+     * scroll background containers.
+     */
+    this.emojiScrollBox.current.scrollTop = 1;
     this.emojiScrollBox.current.addEventListener('scroll',
       this.preventOutsideScrolling,
       false
@@ -75,6 +85,8 @@ class EmojiSelect extends React.Component {
     let scrollHeight = this.emojiScrollBox.current.scrollHeight;
     let offsetHeight = this.emojiScrollBox.current.offsetHeight;
     let contentHeight = scrollHeight - offsetHeight;
+
+    console.log(scrollTop, scrollHeight, offsetHeight, contentHeight);
 
     if (contentHeight <= scrollTop) {  // Box is scrolled to the bottom
       this.emojiScrollBox.current.scrollTop = contentHeight - 1;

--- a/src/Components/Messages/MessageList.js
+++ b/src/Components/Messages/MessageList.js
@@ -73,8 +73,6 @@ class MessageList extends React.Component {
       }
     }
 
-    console.log(messageGroups)
-    console.log(messages)
     // Handle end edge case
     if (currGroup.length !== 0) messageGroups.push(currGroup);
 
@@ -108,7 +106,6 @@ export default MessageList;
 class MessageGroup extends React.Component {
   constructor(props) {
     super(props);
-    console.log(props.messages)
     this.format = (props.messages[0].sender === LOGGED_IN_USER)
       ? 'sent'
       : 'recieved'


### PR DESCRIPTION
Fix issue where scrolling to the top or bottom of the \<EmojiSelect> container would scroll outside content. The way I fixed it is by getting the scroll height of the container and checking if it hits the top or bottom of the container. If it collides with the top or bottom, the scrollTop is reset to its position right before the collision.